### PR TITLE
Tweaks to prophet example

### DIFF
--- a/examples/prophet/MLproject
+++ b/examples/prophet/MLproject
@@ -8,3 +8,7 @@ entry_points:
       csv_url: {type: uri, default: 'https://raw.githubusercontent.com/facebook/prophet/e21a05f4f9290649255a2a306855e8b4620816d7/examples/example_wp_log_peyton_manning.csv'}
       rolling_window: {type: float, default: 0.1}
     command: "python train.py {csv_url} {rolling_window}"
+  predict:
+    parameters:
+      model_uri: {type: uri}
+    command: "python predict.py {model_uri}"

--- a/examples/prophet/predict.py
+++ b/examples/prophet/predict.py
@@ -1,0 +1,16 @@
+import sys
+
+import pandas as pd
+from fbprophet import Prophet
+
+import mlflow.pyfunc
+
+
+model_uri = sys.argv[1]
+model = mlflow.pyfunc.load_model(sys.argv[1])
+print("Loaded model from URI: {}".format(model_uri))
+
+data = {'periods':[5]}
+df = pd.DataFrame(data)
+out = model.predict(model_input=data)
+print(out)

--- a/examples/prophet/predict.py
+++ b/examples/prophet/predict.py
@@ -12,5 +12,5 @@ print("Loaded model from URI: {}".format(model_uri))
 
 data = {'periods':[5]}
 df = pd.DataFrame(data)
-out = model.predict(model_input=data)
+out = model.predict(model_input=df)
 print(out)

--- a/examples/prophet/train.ipynb
+++ b/examples/prophet/train.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# MLflow Prophet Tutorial\n",
     "\n",

--- a/examples/prophet/train.ipynb
+++ b/examples/prophet/train.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,13 +53,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# page view stats\n",
     "def train(rolling_window):\n",
-    "    import os\n",
     "    import warnings\n",
     "    import sys\n",
     "\n",
@@ -110,61 +109,9 @@
     "        mlflow.log_metric(\"rmse\", df_p.loc[0,'rmse'])\n",
     "\n",
     "        model = FbProphetWrapper(m)\n",
-    "        mlflow.pyfunc.log_model(\"model\", conda_env=conda_env, python_model=model )\n",
-    "        return model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": "INFO:fbprophet:Disabling daily seasonality. Run prophet with daily_seasonality=True to override this.\nINFO:fbprophet:Making 11 forecasts with cutoffs between 2010-02-15 00:00:00 and 2015-01-20 00:00:00\nProphet model (rolling_window=0.100000):\n  CV: \n          ds      yhat  yhat_lower  yhat_upper         y     cutoff\n0 2010-02-16  8.960441    8.459464    9.468232  8.242493 2010-02-15\n1 2010-02-17  8.726966    8.233446    9.192014  8.008033 2010-02-15\n2 2010-02-18  8.610869    8.096453    9.075837  8.045268 2010-02-15\n3 2010-02-19  8.532795    8.037051    9.053431  7.928766 2010-02-15\n4 2010-02-20  8.274904    7.807443    8.790022  7.745003 2010-02-15\n  Perf: \n  horizon       mse      rmse       mae      mape  coverage\n0 37 days  0.495161  0.703677  0.505237  0.058536  0.689127\n1 38 days  0.500957  0.707783  0.510231  0.059114  0.687985\n2 39 days  0.523235  0.723350  0.516340  0.059715  0.685244\n3 40 days  0.530583  0.728411  0.519241  0.060026  0.688899\n4 41 days  0.538145  0.733584  0.520267  0.060108  0.696437\n"
-    }
-   ],
-   "source": [
-    "model = train(0.1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ds</th>\n      <th>trend</th>\n      <th>yhat_lower</th>\n      <th>yhat_upper</th>\n      <th>trend_lower</th>\n      <th>trend_upper</th>\n      <th>additive_terms</th>\n      <th>additive_terms_lower</th>\n      <th>additive_terms_upper</th>\n      <th>weekly</th>\n      <th>weekly_lower</th>\n      <th>weekly_upper</th>\n      <th>yearly</th>\n      <th>yearly_lower</th>\n      <th>yearly_upper</th>\n      <th>multiplicative_terms</th>\n      <th>multiplicative_terms_lower</th>\n      <th>multiplicative_terms_upper</th>\n      <th>yhat</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>0</td>\n      <td>2007-12-10</td>\n      <td>8.041239</td>\n      <td>8.232240</td>\n      <td>9.415542</td>\n      <td>8.041239</td>\n      <td>8.041239</td>\n      <td>0.802931</td>\n      <td>0.802931</td>\n      <td>0.802931</td>\n      <td>0.352295</td>\n      <td>0.352295</td>\n      <td>0.352295</td>\n      <td>0.450636</td>\n      <td>0.450636</td>\n      <td>0.450636</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>8.844170</td>\n    </tr>\n    <tr>\n      <td>1</td>\n      <td>2007-12-11</td>\n      <td>8.039695</td>\n      <td>7.953456</td>\n      <td>9.207061</td>\n      <td>8.039695</td>\n      <td>8.039695</td>\n      <td>0.553003</td>\n      <td>0.553003</td>\n      <td>0.553003</td>\n      <td>0.119639</td>\n      <td>0.119639</td>\n      <td>0.119639</td>\n      <td>0.433364</td>\n      <td>0.433364</td>\n      <td>0.433364</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>8.592697</td>\n    </tr>\n    <tr>\n      <td>2</td>\n      <td>2007-12-12</td>\n      <td>8.038151</td>\n      <td>7.760663</td>\n      <td>9.000357</td>\n      <td>8.038151</td>\n      <td>8.038151</td>\n      <td>0.350363</td>\n      <td>0.350363</td>\n      <td>0.350363</td>\n      <td>-0.066664</td>\n      <td>-0.066664</td>\n      <td>-0.066664</td>\n      <td>0.417027</td>\n      <td>0.417027</td>\n      <td>0.417027</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>8.388514</td>\n    </tr>\n    <tr>\n      <td>3</td>\n      <td>2007-12-13</td>\n      <td>8.036607</td>\n      <td>7.759347</td>\n      <td>9.001459</td>\n      <td>8.036607</td>\n      <td>8.036607</td>\n      <td>0.329817</td>\n      <td>0.329817</td>\n      <td>0.329817</td>\n      <td>-0.072254</td>\n      <td>-0.072254</td>\n      <td>-0.072254</td>\n      <td>0.402070</td>\n      <td>0.402070</td>\n      <td>0.402070</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>8.366423</td>\n    </tr>\n    <tr>\n      <td>4</td>\n      <td>2007-12-14</td>\n      <td>8.035063</td>\n      <td>7.735806</td>\n      <td>8.973722</td>\n      <td>8.035063</td>\n      <td>8.035063</td>\n      <td>0.319321</td>\n      <td>0.319321</td>\n      <td>0.319321</td>\n      <td>-0.069578</td>\n      <td>-0.069578</td>\n      <td>-0.069578</td>\n      <td>0.388900</td>\n      <td>0.388900</td>\n      <td>0.388900</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>8.354384</td>\n    </tr>\n    <tr>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n    </tr>\n    <tr>\n      <td>2905</td>\n      <td>2016-01-21</td>\n      <td>7.558493</td>\n      <td>7.916167</td>\n      <td>9.202515</td>\n      <td>7.558493</td>\n      <td>7.558493</td>\n      <td>0.999819</td>\n      <td>0.999819</td>\n      <td>0.999819</td>\n      <td>-0.072254</td>\n      <td>-0.072254</td>\n      <td>-0.072254</td>\n      <td>1.072073</td>\n      <td>1.072073</td>\n      <td>1.072073</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>8.558312</td>\n    </tr>\n    <tr>\n      <td>2906</td>\n      <td>2016-01-22</td>\n      <td>7.557465</td>\n      <td>7.975104</td>\n      <td>9.165059</td>\n      <td>7.557465</td>\n      <td>7.557465</td>\n      <td>1.016808</td>\n      <td>1.016808</td>\n      <td>1.016808</td>\n      <td>-0.069578</td>\n      <td>-0.069578</td>\n      <td>-0.069578</td>\n      <td>1.086386</td>\n      <td>1.086386</td>\n      <td>1.086386</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>8.574273</td>\n    </tr>\n    <tr>\n      <td>2907</td>\n      <td>2016-01-23</td>\n      <td>7.556437</td>\n      <td>7.756167</td>\n      <td>8.938833</td>\n      <td>7.556437</td>\n      <td>7.556437</td>\n      <td>0.786528</td>\n      <td>0.786528</td>\n      <td>0.786528</td>\n      <td>-0.311713</td>\n      <td>-0.311713</td>\n      <td>-0.311713</td>\n      <td>1.098241</td>\n      <td>1.098241</td>\n      <td>1.098241</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>8.342965</td>\n    </tr>\n    <tr>\n      <td>2908</td>\n      <td>2016-01-24</td>\n      <td>7.555410</td>\n      <td>8.078891</td>\n      <td>9.316118</td>\n      <td>7.555410</td>\n      <td>7.555410</td>\n      <td>1.155519</td>\n      <td>1.155519</td>\n      <td>1.155519</td>\n      <td>0.048276</td>\n      <td>0.048276</td>\n      <td>0.048276</td>\n      <td>1.107243</td>\n      <td>1.107243</td>\n      <td>1.107243</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>8.710929</td>\n    </tr>\n    <tr>\n      <td>2909</td>\n      <td>2016-01-25</td>\n      <td>7.554382</td>\n      <td>8.380861</td>\n      <td>9.632096</td>\n      <td>7.554382</td>\n      <td>7.554382</td>\n      <td>1.465276</td>\n      <td>1.465276</td>\n      <td>1.465276</td>\n      <td>0.352295</td>\n      <td>0.352295</td>\n      <td>0.352295</td>\n      <td>1.112981</td>\n      <td>1.112981</td>\n      <td>1.112981</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>0.0</td>\n      <td>9.019658</td>\n    </tr>\n  </tbody>\n</table>\n<p>2910 rows × 19 columns</p>\n</div>",
-      "text/plain": "             ds     trend  yhat_lower  yhat_upper  trend_lower  trend_upper  \\\n0    2007-12-10  8.041239    8.232240    9.415542     8.041239     8.041239   \n1    2007-12-11  8.039695    7.953456    9.207061     8.039695     8.039695   \n2    2007-12-12  8.038151    7.760663    9.000357     8.038151     8.038151   \n3    2007-12-13  8.036607    7.759347    9.001459     8.036607     8.036607   \n4    2007-12-14  8.035063    7.735806    8.973722     8.035063     8.035063   \n...         ...       ...         ...         ...          ...          ...   \n2905 2016-01-21  7.558493    7.916167    9.202515     7.558493     7.558493   \n2906 2016-01-22  7.557465    7.975104    9.165059     7.557465     7.557465   \n2907 2016-01-23  7.556437    7.756167    8.938833     7.556437     7.556437   \n2908 2016-01-24  7.555410    8.078891    9.316118     7.555410     7.555410   \n2909 2016-01-25  7.554382    8.380861    9.632096     7.554382     7.554382   \n\n      additive_terms  additive_terms_lower  additive_terms_upper    weekly  \\\n0           0.802931              0.802931              0.802931  0.352295   \n1           0.553003              0.553003              0.553003  0.119639   \n2           0.350363              0.350363              0.350363 -0.066664   \n3           0.329817              0.329817              0.329817 -0.072254   \n4           0.319321              0.319321              0.319321 -0.069578   \n...              ...                   ...                   ...       ...   \n2905        0.999819              0.999819              0.999819 -0.072254   \n2906        1.016808              1.016808              1.016808 -0.069578   \n2907        0.786528              0.786528              0.786528 -0.311713   \n2908        1.155519              1.155519              1.155519  0.048276   \n2909        1.465276              1.465276              1.465276  0.352295   \n\n      weekly_lower  weekly_upper    yearly  yearly_lower  yearly_upper  \\\n0         0.352295      0.352295  0.450636      0.450636      0.450636   \n1         0.119639      0.119639  0.433364      0.433364      0.433364   \n2        -0.066664     -0.066664  0.417027      0.417027      0.417027   \n3        -0.072254     -0.072254  0.402070      0.402070      0.402070   \n4        -0.069578     -0.069578  0.388900      0.388900      0.388900   \n...            ...           ...       ...           ...           ...   \n2905     -0.072254     -0.072254  1.072073      1.072073      1.072073   \n2906     -0.069578     -0.069578  1.086386      1.086386      1.086386   \n2907     -0.311713     -0.311713  1.098241      1.098241      1.098241   \n2908      0.048276      0.048276  1.107243      1.107243      1.107243   \n2909      0.352295      0.352295  1.112981      1.112981      1.112981   \n\n      multiplicative_terms  multiplicative_terms_lower  \\\n0                      0.0                         0.0   \n1                      0.0                         0.0   \n2                      0.0                         0.0   \n3                      0.0                         0.0   \n4                      0.0                         0.0   \n...                    ...                         ...   \n2905                   0.0                         0.0   \n2906                   0.0                         0.0   \n2907                   0.0                         0.0   \n2908                   0.0                         0.0   \n2909                   0.0                         0.0   \n\n      multiplicative_terms_upper      yhat  \n0                            0.0  8.844170  \n1                            0.0  8.592697  \n2                            0.0  8.388514  \n3                            0.0  8.366423  \n4                            0.0  8.354384  \n...                          ...       ...  \n2905                         0.0  8.558312  \n2906                         0.0  8.574273  \n2907                         0.0  8.342965  \n2908                         0.0  8.710929  \n2909                         0.0  9.019658  \n\n[2910 rows x 19 columns]"
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import os\n",
-    "import warnings\n",
-    "import sys\n",
-    "\n",
-    "import pandas as pd\n",
-    "import numpy as np\n",
-    "# Python\n",
-    "from fbprophet import Prophet\n",
-    "from fbprophet.diagnostics import cross_validation\n",
-    "from fbprophet.diagnostics import performance_metrics\n",
-    "\n",
-    "import mlflow\n",
-    "import mlflow.pyfunc\n",
-    "\n",
-    "import logging\n",
-    "\n",
-    "data = { 'periods':[5]}\n",
-    "df = pd.DataFrame(data) \n",
-    "out = model.predict(context={}, model_input=data)\n",
-    "out"
+    "        mlflow.pyfunc.log_model(\"model\", conda_env=conda_env, python_model=model)\n",
+    "        model_uri = \"runs:/{run_id}/model\".format(run_id=mlflow.active_run().info.run_id)\n",
+    "        return model_uri"
    ]
   },
   {
@@ -172,7 +119,26 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "model_uri = train(0.1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import mlflow.pyfunc\n",
+    "\n",
+    "model = mlflow.pyfunc.load_model(model_uri)\n",
+    "\n",
+    "data = { 'periods':[5]}\n",
+    "df = pd.DataFrame(data) \n",
+    "out = model.predict(context={}, model_input=data)\n",
+    "out"
+   ]
   }
  ],
  "metadata": {
@@ -191,7 +157,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/examples/prophet/train.ipynb
+++ b/examples/prophet/train.ipynb
@@ -134,9 +134,9 @@
     "\n",
     "model = mlflow.pyfunc.load_model(model_uri)\n",
     "\n",
-    "data = { 'periods':[5]}\n",
+    "data = {'periods': [5]}\n",
     "df = pd.DataFrame(data) \n",
-    "out = model.predict(context={}, model_input=data)\n",
+    "out = model.predict(model_input=df)\n",
     "out"
    ]
   }

--- a/examples/prophet/train.py
+++ b/examples/prophet/train.py
@@ -1,6 +1,5 @@
 # The data set used in this example is from 'https://raw.githubusercontent.com/facebook/prophet/master/examples/example_wp_log_peyton_manning.csv'
 
-import os
 import warnings
 import sys
 


### PR DESCRIPTION
This PR makes the following tweaks to the prophet example:

1. Introduces a `predict.py` script and MLProject entrypoint for performing inference
2. Changes the inference procedure used in the notebook to load the model via `mlflow.pyfunc.load_model` and invoke `model.predict(df)` with a single Pandas DataFrame argument.
3. Removes unused imports
4. Formats the example code